### PR TITLE
Fixed ITransactionCommon Memos

### DIFF
--- a/Tests/Xrpl.Tests/TestConnection.cs
+++ b/Tests/Xrpl.Tests/TestConnection.cs
@@ -57,7 +57,7 @@ namespace Xrpl.Tests
 
         [TestMethod]
         [ExpectedException(typeof(NotConnectedException))]
-        public async void TestNotConnectedException()
+        public async Task TestNotConnectedException()
         {
             ConnectionOptions options = new ConnectionOptions();
             Connection connection = new Connection("url", options);

--- a/Xrpl/Models/Transactions/Common.cs
+++ b/Xrpl/Models/Transactions/Common.cs
@@ -250,7 +250,7 @@ namespace Xrpl.Models.Transactions
         /// <inheritdoc />
         public uint? LastLedgerSequence { get; set; }
         /// <inheritdoc />
-        public List<Memo> Memos { get; set; }
+        public List<MemoWrapper> Memos { get; set; }
         /// <inheritdoc />
         public uint? Sequence { get; set; }
         /// <inheritdoc />
@@ -575,7 +575,7 @@ namespace Xrpl.Models.Transactions
         /// <summary>
         /// Additional arbitrary information used to identify this transaction.
         /// </summary>
-        List<Memo> Memos { get; set; }
+        List<MemoWrapper> Memos { get; set; }
 
         /// <summary>
         /// Transaction metadata is a section of data that gets added to a transaction after it is processed.<br/>
@@ -653,7 +653,7 @@ namespace Xrpl.Models.Transactions
         public uint? LastLedgerSequence { get; set; }
 
         /// <inheritdoc/>
-        public List<Memo> Memos { get; set; }
+        public List<MemoWrapper> Memos { get; set; }
         /// <inheritdoc/>
         public uint? Sequence { get; set; }
         /// <inheritdoc/>


### PR DESCRIPTION
Memo class names were refactored but the type of the `Memos` list in `ITransactionCommon` was not updated to `MemoWrapper`. 
