### PR TITLE
Create NugetPublish.yml

### DIFF
--- a/.github/workflows/NugetPublish.yml
+++ b/.github/workflows/NugetPublish.yml
@@ -1,0 +1,37 @@
+name: .NET
+
+on:
+  push:
+    branches: [ nuget_publish ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 7.0.x
+        
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Build
+      run: dotnet build --no-restore
+      
+    - name: Test
+      run: dotnet test --no-build --verbosity normal
+      
+    - name: Packing
+      run: |
+          dotnet build Xrpl/Xrpl.csproj -c Release
+          dotnet pack Xrpl/Xrpl.csproj -c Release
+          
+    - name: Push package
+      run: dotnet nuget push "**/*.nupkg" --skip-duplicate --source https://nuget.pkg.github.com/dangell7/index.json -k ${{secrets.GITHUB_TOKEN}}     
+  
+    - name: Publishing
+      run: dotnet nuget push "**/*.nupkg" -k ${{ secrets.NuGetApiKey }} --skip-duplicate -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
nuget publish script
will start when you push to `nuget_publish` branch
the package will be placed in nuget and git.Nuget
(git owner @dangell7 )

before push
You need to increase package version in Xrpl.csproj `<PackageVersion>2.0.0</PackageVersion>`

Also you need to create nuget api key in project settings, like in my sample
![image](https://user-images.githubusercontent.com/44946855/229348400-a3cb1422-ac70-46ec-9499-8319bd7db80c.png)
